### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Python >= 3.9
 anyio==3.7.0
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
@@ -22,7 +23,7 @@ executing==1.2.0
 fastjsonschema==2.17.1
 flit_core==3.9.0
 FMPy==0.3.16
-fonttools==4.40.0
+fonttools==4.43.0
 gekko==1.0.6
 idna==3.4
 imageio==2.31.1
@@ -34,14 +35,14 @@ ipython==8.12.0
 ipython-genutils==0.2.0
 ipywidgets==8.0.6
 jedi==0.18.2
-Jinja2==3.1.2
-jsonschema==4.17.3
+Jinja2==3.1.3
+jsonschema==4.18.0
 jupyter==1.0.0
 jupyter_client==8.2.0
 jupyter-console==6.6.3
 jupyter_core==5.3.1
-jupyter-events==0.6.3
-jupyter_server==2.7.2
+jupyter-events==0.9.0
+jupyter_server==2.11.2
 jupyter_server_terminals==0.4.4
 jupyterlab-pygments==0.2.2
 jupyterlab-widgets==3.0.7
@@ -61,15 +62,15 @@ nbformat==5.9.0
 nest-asyncio==1.5.6
 notebook==6.5.4
 notebook_shim==0.2.3
-numpy==1.24.3
+numpy==1.26.3
 overrides==7.3.1
 packaging==23.1
 pandas==2.0.2
 pandocfilters==1.5.0
 parso==0.8.3
 pickleshare==0.7.5
-Pillow==10.0.1
-pip==23.1.2
+Pillow==10.2.0
+pip==23.3
 pkgutil_resolve_name==1.3.10
 platformdirs==3.6.0
 ply==3.11
@@ -88,9 +89,6 @@ pyrsistent==0.19.3
 pyserial==3.5
 python-dateutil==2.8.2
 python-json-logger==2.0.7
-pytz==2023.3
-pywin32==304
-pywinpty==2.0.10
 PyYAML==6.0
 pyzmq==25.1.0
 qtconsole==5.4.3


### PR DESCRIPTION
-Updated based on security alert-
pip
jupyter-server
fonttools
jinja2
Pillow

-The dependency above-
jupyter-events
jsonschema

-For the newer python version-
numpy

-deleted because of no use and (obsolete or python version problem)- 
ref) https://groups.google.com/g/django-developers/c/PtIyadoC-fI 
pytz
pywin32
pywinpty

add recommendation of python >=3.9

tested on M1 Mac